### PR TITLE
Handle missing Segment write key

### DIFF
--- a/app/analyticsInstance.ts
+++ b/app/analyticsInstance.ts
@@ -1,15 +1,47 @@
 import { Analytics } from '@segment/analytics-node'
 
-const analyticsSingleton = () => {
-  return new Analytics({ writeKey: process.env.NEXT_PUBLIC_SEGMENT_WRITE_KEY as string})
+type AnalyticsClient = Pick<
+  Analytics,
+  'track' | 'identify' | 'group' | 'page' | 'screen' | 'alias' | 'flush'
+>
+
+const createNoopAnalytics = (): AnalyticsClient => {
+  const noop = async () => {}
+
+  if (process.env.NODE_ENV !== 'production') {
+    console.warn('Segment write key not configured. Analytics disabled.')
+  }
+
+  return {
+    track: noop,
+    identify: noop,
+    group: noop,
+    page: noop,
+    screen: noop,
+    alias: noop,
+    flush: noop,
+  }
+}
+
+const analyticsSingleton = (): AnalyticsClient => {
+  const writeKey = process.env.NEXT_PUBLIC_SEGMENT_WRITE_KEY
+
+  if (!writeKey) {
+    return createNoopAnalytics()
+  }
+
+  return new Analytics({ writeKey })
 }
 
 declare global {
-  var analyticsGlobal: undefined | ReturnType<typeof analyticsSingleton>
+  // eslint-disable-next-line no-var
+  var analyticsGlobal: AnalyticsClient | undefined
 }
 
 const analytics = globalThis.analyticsGlobal ?? analyticsSingleton()
 
 export default analytics
 
-if (process.env.NODE_ENV !== 'production') globalThis.analyticsGlobal = analytics
+if (process.env.NODE_ENV !== 'production') {
+  globalThis.analyticsGlobal = analytics
+}


### PR DESCRIPTION
## Summary
- guard analytics initialization with a no-op client when the Segment write key is not configured
- cache the analytics instance with an explicit global type annotation

## Testing
- CI=1 pnpm run build

------
https://chatgpt.com/codex/tasks/task_e_68dbda73c76083218ef0e0b3add645a6